### PR TITLE
Add `CompareQueryHandler` to check Query

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -3,6 +3,7 @@ package reqtest
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -23,6 +24,16 @@ func (g *HandlerGenerator) CompareMethod(method string) http.Handler {
 func (g *HandlerGenerator) ComparePath(path string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if diff := cmp.Diff(req.URL.Path, path); diff != "" {
+			g.OnFailure.Fail(diff)
+			return
+		}
+	})
+}
+
+func (g *HandlerGenerator) CompareQuery(want url.Values) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		got := req.URL.Query()
+		if diff := cmp.Diff(got, want); diff != "" {
 			g.OnFailure.Fail(diff)
 			return
 		}

--- a/reqtest.go
+++ b/reqtest.go
@@ -2,6 +2,7 @@ package reqtest
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 )
 
@@ -19,6 +20,14 @@ func ComparePathHandler(t *testing.T, path string) http.Handler {
 	return (&HandlerGenerator{
 		OnFailure: &TError{t: t},
 	}).ComparePath(path)
+}
+
+func CompareQueryHandler(t *testing.T, want url.Values) http.Handler {
+	t.Helper()
+
+	return (&HandlerGenerator{
+		OnFailure: &TError{t: t},
+	}).CompareQuery(want)
 }
 
 func CompareHeaderValuesHandler(t *testing.T, key string, values []string) http.Handler {


### PR DESCRIPTION
Usage

```golang
// ...
reqtest.CompareQueryHandler(t, url.Values{"foo": {"foo"}),
// ...
```